### PR TITLE
Preserve code blocks

### DIFF
--- a/test/docs/other-project/fence-blocks.md
+++ b/test/docs/other-project/fence-blocks.md
@@ -1,0 +1,29 @@
+```cpp
+// [Test Link](BROKEN_CPP_FENCE_LINK)
+#include <iostream>
+int main(int argc, char **argv) {
+    std::cout << "Hello, world!" << std::endl;
+    return 0;
+}
+```
+
+[Link should work](my-section.md)
+
+```
+[Link should not be altered](my-section.md)
+[[Link should not be altered]]
+![](puppy)
+![Puppy](puppy)
+```
+
+Link won't work:
+`![[puppy]]`
+
+`
+![[Puppy]]
+`
+```
+```
+
+![[Puppy]]
+

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - 'my-project/link_updates.md'
     - 'my-project/section/my-section.md'
     - 'other-project/project.md'
+    - 'other-project/fence-blocks.md'
 theme: readthedocs
 docs_dir: 'docs'
 use_directory_urls: false


### PR DESCRIPTION
* Don't scan any link patterns inside of fence blocks, both inline, and multiline.

* Refactor the regex patterns to leverage the
re.X (verbose) flag, which ignores whitespace within the pattern.

* Various PEP-8 formatting fixes (though not all!)