### PR TITLE
Bugfix/issue 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ plugins:
 plugins:
     - search
     - ezlinks:
-        - wikilinks: {true|false}
+        wikilinks: {true|false}
 ```
 ## wikilinks
 Determines whether to scan for wikilinks or not (See [WikiLink Support](#wikilink-support)).

--- a/mkdocs_ezlinks_plugin/file_mapper.py
+++ b/mkdocs_ezlinks_plugin/file_mapper.py
@@ -6,9 +6,14 @@ from .types import BrokenLink
 
 
 class FileMapper:
-    def __init__(self, root: str, files: list[mkdocs.structure.pages.Page]):
+    def __init__(
+            self,
+            root: str,
+            files: list[mkdocs.structure.pages.Page],
+            logger=None):
         self.root = root
         self.file_map = {}
+        self.logger = logger
 
         for file in files:
             # Ignore any files generated from files outside of the docs root,
@@ -20,7 +25,8 @@ class FileMapper:
                 if not self.file_map.get(search_name):
                     self.file_map[search_name] = []
                 else:
-                    print(f"WARNING -  Duplicate filename `{search_name}` detected. Linking to it will only match the first file.")
+                    self.logger.debug("[EzLinks] Duplicate filename "
+                                      f"`{search_name}` detected.")
                 self.file_map[search_name].append(file.src_path)
 
     def search(self, file_name: str):
@@ -32,10 +38,12 @@ class FileMapper:
                     return None
                 abs_to = files[0]
                 if len(files) > 1:
-                    print(f"WARNING -  Link targeting a duplicate file '{file_name}'.")
+                    duplicates = ""
                     for idx, file in enumerate(files):
                         active = "<-- Active" if idx == 0 else ""
-                        print(f"  [{idx}]   - {file} {active}")
+                        duplicates += f"  [{idx}]   - {file} {active}"
+                    self.logger.debug("[EzLinks] Link targeting a duplicate"
+                                      f"file '{file_name}'.\n{duplicates}")
             abs_to = abs_to + '.md' if '.' not in abs_to else abs_to
             return os.path.join(self.root, abs_to)
 

--- a/mkdocs_ezlinks_plugin/file_mapper.py
+++ b/mkdocs_ezlinks_plugin/file_mapper.py
@@ -41,9 +41,9 @@ class FileMapper:
                     duplicates = ""
                     for idx, file in enumerate(files):
                         active = "<-- Active" if idx == 0 else ""
-                        duplicates += f"  [{idx}]   - {file} {active}"
-                    self.logger.debug("[EzLinks] Link targeting a duplicate"
-                                      f"file '{file_name}'.\n{duplicates}")
+                        duplicates += f"  [{idx}]   - {file} {active}\n"
+                    self.logger.warning("[EzLinks] Link targeting a duplicate "
+                                        f"file '{file_name}'.\n{duplicates}")
             abs_to = abs_to + '.md' if '.' not in abs_to else abs_to
             return os.path.join(self.root, abs_to)
 

--- a/mkdocs_ezlinks_plugin/plugin.py
+++ b/mkdocs_ezlinks_plugin/plugin.py
@@ -1,10 +1,16 @@
+import logging
+
 import mkdocs
+from mkdocs.utils import warning_filter
 
 from .file_mapper import FileMapper
 from .replacer import EzLinksReplacer
 from .scanners.md_link_scanner import MdLinkScanner
 from .scanners.wiki_link_scanner import WikiLinkScanner
 from .types import EzLinksOptions
+
+LOGGER = logging.getLogger(f"mkdocs.plugins.{__name__}")
+LOGGER.addFilter(warning_filter)
 
 
 class EzLinksPlugin(mkdocs.plugins.BasePlugin):
@@ -16,7 +22,8 @@ class EzLinksPlugin(mkdocs.plugins.BasePlugin):
         self.replacer = EzLinksReplacer(
             root=config['docs_dir'],
             file_map=self.file_mapper,
-            options=EzLinksOptions(**self.config, strict=config['strict'])
+            options=EzLinksOptions(**self.config),
+            logger=LOGGER
         )
 
         self.replacer.add_scanner(MdLinkScanner())
@@ -30,7 +37,8 @@ class EzLinksPlugin(mkdocs.plugins.BasePlugin):
     def on_files(self, files: list[mkdocs.structure.files.File], config):
         self.file_mapper = FileMapper(
             root=config['docs_dir'],
-            files=files
+            files=files,
+            logger=LOGGER
         )
 
         # After the file map has been built, initialize what we can that will

--- a/mkdocs_ezlinks_plugin/replacer.py
+++ b/mkdocs_ezlinks_plugin/replacer.py
@@ -12,11 +12,13 @@ class EzLinksReplacer:
             self,
             root: str,
             file_map: FileMapper,
-            options: EzLinksOptions):
+            options: EzLinksOptions,
+            logger):
         self.root = root
         self.file_map = file_map
         self.options = options
         self.scanners = []
+        self.logger = logger
 
     def add_scanner(self, scanner: BaseLinkScanner) -> None:
         self.scanners.append(scanner)
@@ -68,15 +70,15 @@ class EzLinksReplacer:
                         # Otherwise, search for the target through the file map
                         search_result = self.file_map.search(link.target)
                         if not search_result:
-                            raise BrokenLink(f"Did not find '{link.target}' in file map.")
+                            raise BrokenLink(f"'{link.target}' not found.")
                         link.target = search_result
 
                     link.target = os.path.relpath(link.target, abs_from)
                     return link.render()
         except BrokenLink as ex:
-            if self.options.strict:
-                print(f"ERROR -  {ex}")
-            else:
-                print(f"WARNING -  {ex}")
+            # Log these out as Debug messages, as the regular mkdocs
+            # strict mode will log out broken links.
+            self.logger.debug(f"[EzLinks] {ex}")
+
         # Fall through, return the original link unaltered, and let mkdocs handle it
         return match.group(0)

--- a/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
+++ b/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
@@ -29,6 +29,7 @@ class MdLinkScanner(BaseLinkScanner):
             )
             \(
                 (?P<md_target>
+                    (?!http://|https://)
                     (?P<md_filename>\/?[^\#\ \)]*)?
                     (?:\#(?P<md_anchor>[^\)\"]*)?)?
                     (?:\ \"(?P<md_title>[^\"\)]*)\")?

--- a/mkdocs_ezlinks_plugin/types.py
+++ b/mkdocs_ezlinks_plugin/types.py
@@ -25,5 +25,4 @@ class Link:
 @dataclass
 class EzLinksOptions:
     ''' Dataclass to hold typed options from the configuration. '''
-    strict: bool
     wikilinks: bool

--- a/test/docs/my-project/link_updates.md
+++ b/test/docs/my-project/link_updates.md
@@ -12,3 +12,9 @@
 
 [[#Section Heading|Title]]
 
+
+
+[External Link](https://www.example.com)
+[External Link](http://www.example.com)
+[External Link w/ Title](https://www.example.com "LINK TITLE")
+[External link no scheme](www.example.com)

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -12,4 +12,5 @@ docs_dir: 'docs'
 use_directory_urls: false
 plugins:
     - search
-    - ezlinks
+    - ezlinks:
+       wikilinks: true


### PR DESCRIPTION
Various fixes spawing from issues reported in #12

* Do not scan external links with an http:// or https:// prefix,
  which will prevent properly formatted external links from
  emitting a warning for a missing link target.

* Includes an __init__.py for the mkdocs_ezlinks_plugin/scanners
  module, which then is included into the distribution.

* Also downgrades some prior warnings to debug level,
  as most of the messages trigger existing mkdocs warnings
  (such as broken link warnings, etc.)

* Messages are now automatically filtered based on the
  '--quiet' and '--verbose' mkdocs flags.

* Update `Configuration Options` in README.md
