### PR TITLE
Fixes issue with multiple links on a single line

### DIFF
--- a/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
+++ b/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
@@ -24,7 +24,7 @@ class MdLinkScanner(BaseLinkScanner):
                 |
                 (?P<md_alt_is_image>\!?)
                 \[
-                    (?P<md_text>.+)
+                    (?P<md_text>[^\]]+)
                 \]
             )
             \(

--- a/test/docs/my-project/link_updates.md
+++ b/test/docs/my-project/link_updates.md
@@ -18,3 +18,16 @@
 [External Link](http://www.example.com)
 [External Link w/ Title](https://www.example.com "LINK TITLE")
 [External link no scheme](www.example.com)
+
+MD Links:
+
+[My Section](my-section) [My Section Link 2](my-section.md) [My Section Link 3](my-section.md#anchor "Test")
+
+
+WikiLinks:
+
+[[My Section]] [[My Section|My Section 2]] [[My Section|My Section 3]]
+
+Both:
+
+[[My Section|Wiki Link]] [My Section 2](my-section) [[Fence Blocks]]


### PR DESCRIPTION
* If there was more than a single MD link on a single line in
  a page, the Regex would capture too aggressively, ending up
  with a broken capture

* Adds some tests for single line with multiple links

Resolves: #16