### PR TITLE
Fix functional relative links, and add auto-disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,25 @@ Determines whether to warn when an abmiguous link is encountered. An ambiguous l
 If you had any links that targeted `index.md`, EzLinks is not able to determine _which_ of the instances of `index.md` to target, thus it is ambiguous.
 
 ### Disambiguating links
-In the circumstance above, it would be possible to disambiguate _which_ `index.md` by including the containing folder, e.g. `folder1/index.md` or `folder2/index.md`. Note: This also works in conjunction with extension-less targets, e.g. `folder1/index` and `folder2/index`.
+By default, EzLinks will attempt to resolve the ambiguity automatically. It does this by searching for the file closest to the file that is linking (with respect to the folder hierarchy).
 
-This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/index.md`, specifying as many path components as necessary to fully disambiguate the links.
+```
++ guide/
+  + test.md
+  + getting_started/
+      + index.md
++ tutorials/
+  - test.md
+  + getting_started/
+      + index.md
+  + more_advanced/
+      + index.md
+```
+If you placed a link inside `guide/getting_started/index.md` such as `[Test](test)`, the resulting link has ambiguity, but in the default case, the `guide/test.md` file is _closer_ than the `tutorials/test.md`, therefore, it will select that file.
+
+In the circumstance above, it would be possible to disambiguate _which_ `test.md` by including the containing folder, e.g. `guide/test.md` or `tutorials/test.md`. Note: This also works in conjunction with extension-less targets, e.g. `guide/test` and `tutorials/test`.
+
+This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/test.md`, specifying as many path components as necessary to fully disambiguate the links.
 
 This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]].
 

--- a/mkdocs_ezlinks_plugin/plugin.py
+++ b/mkdocs_ezlinks_plugin/plugin.py
@@ -24,6 +24,7 @@ class EzLinksPlugin(mkdocs.plugins.BasePlugin):
         self.replacer = EzLinksReplacer(
             root=config['docs_dir'],
             file_map=self.file_mapper,
+            use_directory_urls=config['use_directory_urls'],
             options=EzLinksOptions(**self.config),
             logger=LOGGER
         )

--- a/mkdocs_ezlinks_plugin/replacer.py
+++ b/mkdocs_ezlinks_plugin/replacer.py
@@ -12,10 +12,12 @@ class EzLinksReplacer:
             self,
             root: str,
             file_map: FileMapper,
+            use_directory_urls: bool,
             options: EzLinksOptions,
             logger):
         self.root = root
         self.file_map = file_map
+        self.use_directory_urls = use_directory_urls
         self.options = options
         self.scanners = []
         self.logger = logger
@@ -70,6 +72,9 @@ class EzLinksReplacer:
                     else:
                         # Otherwise, search for the target through the file map
                         search_result = self.file_map.search(self.path, link.target)
+                        if not self.use_directory_urls:
+                            search_result = search_result + '.md' if '.' not in search_result else search_result
+
                         if not search_result:
                             raise BrokenLink(f"'{link.target}' not found.")
                         link.target = search_result

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ with open("README.md", 'r') as f:
 
 setup(
   name='mkdocs-ezlinks-plugin',
-  version='0.1.9',
+  version='0.1.10',
   description=description,
   long_description=long_description,
   long_description_content_type='text/markdown',
   keywords='mkdocs',
   url='https://github.com/orbikm/mkdocs-ezlinks-plugin',
-  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.9.tar.gz',
+  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.10.tar.gz',
   author='Mick Orbik',
   author_email='mick.orbik@gmail.com',
   license='MIT',

--- a/test/docs/disambiguation/sub1/sub2/index.md
+++ b/test/docs/disambiguation/sub1/sub2/index.md
@@ -1,0 +1,3 @@
+# Sub2/Index
+
+[About (should link to sub2/about)](about)

--- a/test/docs/disambiguation/sub3/sub4/index.md
+++ b/test/docs/disambiguation/sub3/sub4/index.md
@@ -1,0 +1,3 @@
+# Sub3/Sub4/index
+
+[Test (should goto sub4/about)](about)


### PR DESCRIPTION
Implement auto-disambiguation and bugfix
    
    * This fixes a bug in the previous search strategy that missed
      allowing for local relative links (something like index.md
      referring to about.md in the same subdirectory).
    
    * It also adds a bit further auto-disambiguation. By this,
      I mean it will attempt to find the _closest_ match in proximity
      (with respect to the folder hierarchy). For instance,
      if this is the layout:
    
      ```
      + guide/
        + test.md
        + getting_started/
            + index.md
      + tutorials/
        - test.md
        + getting_started/
           + index.md
        + more_advanced/
           + index.md
      ```
      If you placed a link inside `guide/getting_started/index.md`
      such as `[Test](test)`, the resulting link has ambiguity, but
      in the default case, the `guide/test.md` file is _closer_ than
      the `tutorials/test.md`, therefore, it will select that file.
    
      You can still further disambiguate the link if desired, but
      this provides a bit more sane defaults.