### PR TITLE
Release 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,25 @@ Determines whether to warn when an abmiguous link is encountered. An ambiguous l
 If you had any links that targeted `index.md`, EzLinks is not able to determine _which_ of the instances of `index.md` to target, thus it is ambiguous.
 
 ### Disambiguating links
-In the circumstance above, it would be possible to disambiguate _which_ `index.md` by including the containing folder, e.g. `folder1/index.md` or `folder2/index.md`. Note: This also works in conjunction with extension-less targets, e.g. `folder1/index` and `folder2/index`.
+By default, EzLinks will attempt to resolve the ambiguity automatically. It does this by searching for the file closest to the file that is linking (with respect to the folder hierarchy).
 
-This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/index.md`, specifying as many path components as necessary to fully disambiguate the links.
+```
++ guide/
+  + test.md
+  + getting_started/
+      + index.md
++ tutorials/
+  - test.md
+  + getting_started/
+      + index.md
+  + more_advanced/
+      + index.md
+```
+If you placed a link inside `guide/getting_started/index.md` such as `[Test](test)`, the resulting link has ambiguity, but in the default case, the `guide/test.md` file is _closer_ than the `tutorials/test.md`, therefore, it will select that file.
+
+In the circumstance above, it would be possible to disambiguate _which_ `test.md` by including the containing folder, e.g. `guide/test.md` or `tutorials/test.md`. Note: This also works in conjunction with extension-less targets, e.g. `guide/test` and `tutorials/test`.
+
+This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/test.md`, specifying as many path components as necessary to fully disambiguate the links.
 
 This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]].
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In the circumstance above, it would be possible to disambiguate _which_ `test.md
 
 This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/test.md`, specifying as many path components as necessary to fully disambiguate the links.
 
-This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]].
+This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]]`.
 
 ## wikilinks
 Determines whether to scan for wikilinks or not (See [WikiLink Support](#wikilink-support)).
@@ -133,6 +133,14 @@ and these links are entered in `folder1/main.md`, this is how wikilinks will be 
 | `[[Page Name\|Link Text]]` | `[Link Text](../folder2/page-name.md)` |
 | `[[Page Name#Section Heading\|Link Text]]` | `[Link Text](../folder2/page-name.md#section-heading)` |
 
+# Release Log
+I am going to start tracking changes per release in this section. I will backfill the prior release history when I have a chance, but will maintain the release log for each new release.
+
+## Release 0.1.11
+This is a bugfix release. The prior release switched from a dictionary lookup to a prefix trie lookup strategy, which allowed for better disambiguation between links, but is more expensive. The bug was that, even if a link was direct, it would trigger a full trie search. Now, direct links
+are checked and returned directly if the file exists.
+
+Additionally, a slight performance improvement was made where, in the case that a filename is unique to the entire site, it will rely on a fast dictionary lookup instead of a trie lookup.
 
 # Attribution
 This work is highly inspired from the following plugins:

--- a/mkdocs_ezlinks_plugin/file_mapper.py
+++ b/mkdocs_ezlinks_plugin/file_mapper.py
@@ -16,6 +16,7 @@ class FileMapper:
             logger=None):
         self.options = options
         self.root = root
+        self.file_cache = {}
         self.file_trie = pygtrie.StringTrie(separator=os.sep)
         self.logger = logger
 
@@ -30,52 +31,76 @@ class FileMapper:
         # without file extension.
         search_exprs = [file_path, os.path.splitext(file_path)[0]]
         for search_expr in search_exprs:
+            # Store in fast file cache
+            file_name = os.path.basename(search_expr)
+            if file_name not in self.file_cache:
+                self.file_cache[file_name] = [file_path]
+            else:
+                self.file_cache[file_name].append(file_path)
+
+            # Store in trie
             components = list(search_expr.split(os.sep))
             components.reverse()
             self.file_trie[os.sep.join(components)] = file_path
 
-    def search(self, from_file: str, file_name: str):
-        abs_to = file_name
+        # Reduce the dictionary to only search terms that are unique
+        self.file_cache = {k: v for (k, v) in self.file_cache.items() if len(v) > 1}
+
+    def search(self, from_file: str, file_path: str):
+        abs_to = file_path
+        # Detect if it's an absolute link, then just return it directly
         if abs_to.startswith('/'):
-            abs_to = abs_to[1:]
+            return os.path.join(self.root, abs_to[1:])
         else:
-            search_for = list(file_name.split(os.sep))
-            search_for.reverse()
-            search_for = f"{os.sep}".join(search_for)
+            # Check if it is a direct link first
+            from_dir = os.path.dirname(from_file)
+            if os.path.exists(os.path.join(self.root, from_dir, file_path)):
+                return os.path.join(self.root, from_dir, file_path)
 
-            # If we have an _exact_ match in the trie, we don't need to search
-            if search_for in self.file_trie:
-                abs_to = self.file_trie[search_for]
-            elif self.file_trie.has_subtrie(search_for):
-                # If we don't have an exact match, but have a partial prefix
-                values = self.file_trie.values(search_for)
-                abs_to = values[0]
-                has_ambiguity = len(values) > 1
-                # If we have ambiguities, attempt to auto-disambiguate by performing
-                # an iterative ascent of the link file's path. In this way, we should
-                # be able to get the result closest to the file doing the linking
-                if has_ambiguity:
-                    file_path = os.path.dirname(from_file)
-                    components = file_path.split(os.sep)
-                    components.reverse()
-                    for path_component in components:
-                        search_for += f"{os.sep}{path_component}"
-                        if self.file_trie.has_subtrie(search_for) or search_for in self.file_trie:
-                            new_vals = self.file_trie.values(search_for)
-                            if len(new_vals) == 1:
-                                abs_to = new_vals[0]
-                                # We've resolved the ambiguity, so no need to warn
-                                has_ambiguity = False
-                                break
+            # It's an EzLink that must be searched
+            file_name = os.path.basename(file_path)
 
-                if has_ambiguity:
-                    ambiguities = ""
-                    for idx, file in enumerate(values):
-                        active = "<--- (Selected)" if idx == 0 else ""
-                        ambiguities += f"  {idx}: {file} {active}\n"
-                    log_fn = self.logger.warning if self.options.warn_ambiguities else self.logger.debug
-                    log_fn(f"[EzLink] Link ambiguity detected.\n"
-                           f"File: '{from_file}'\n"
-                           f"Link: '{search_for}'\n"
-                           "Ambiguities:\n" + ambiguities)
+            # Check fast file cache first
+            if os.path.basename(file_name) in self.file_cache:
+                abs_to = self.file_cache[file_name]
+            else:
+                search_for = list(file_path.split(os.sep))
+                search_for.reverse()
+                search_for = f"{os.sep}".join(search_for)
+
+                # If we have an _exact_ match in the trie, we don't need to search
+                if search_for in self.file_trie:
+                    abs_to = self.file_trie[search_for]
+                elif self.file_trie.has_subtrie(search_for):
+                    # If we don't have an exact match, but have a partial prefix
+                    values = self.file_trie.values(search_for)
+                    abs_to = values[0]
+                    has_ambiguity = len(values) > 1
+                    # If we have ambiguities, attempt to auto-disambiguate by performing
+                    # an iterative ascent of the link file's path. In this way, we should
+                    # be able to get the result closest to the file doing the linking
+                    if has_ambiguity:
+                        file_path = os.path.dirname(from_file)
+                        components = file_path.split(os.sep)
+                        components.reverse()
+                        for path_component in components:
+                            search_for += f"{os.sep}{path_component}"
+                            if self.file_trie.has_subtrie(search_for) or search_for in self.file_trie:
+                                new_vals = self.file_trie.values(search_for)
+                                if len(new_vals) == 1:
+                                    abs_to = new_vals[0]
+                                    # We've resolved the ambiguity, so no need to warn
+                                    has_ambiguity = False
+                                    break
+
+                    if has_ambiguity:
+                        ambiguities = ""
+                        for idx, file in enumerate(values):
+                            active = "<--- (Selected)" if idx == 0 else ""
+                            ambiguities += f"  {idx}: {file} {active}\n"
+                        log_fn = self.logger.warning if self.options.warn_ambiguities else self.logger.debug
+                        log_fn(f"[EzLink] Link ambiguity detected.\n"
+                               f"File: '{from_file}'\n"
+                               f"Link: '{search_for}'\n"
+                               "Ambiguities:\n" + ambiguities)
         return os.path.join(self.root, abs_to)

--- a/mkdocs_ezlinks_plugin/plugin.py
+++ b/mkdocs_ezlinks_plugin/plugin.py
@@ -24,6 +24,7 @@ class EzLinksPlugin(mkdocs.plugins.BasePlugin):
         self.replacer = EzLinksReplacer(
             root=config['docs_dir'],
             file_map=self.file_mapper,
+            use_directory_urls=config['use_directory_urls'],
             options=EzLinksOptions(**self.config),
             logger=LOGGER
         )

--- a/mkdocs_ezlinks_plugin/replacer.py
+++ b/mkdocs_ezlinks_plugin/replacer.py
@@ -12,10 +12,12 @@ class EzLinksReplacer:
             self,
             root: str,
             file_map: FileMapper,
+            use_directory_urls: bool,
             options: EzLinksOptions,
             logger):
         self.root = root
         self.file_map = file_map
+        self.use_directory_urls = use_directory_urls
         self.options = options
         self.scanners = []
         self.logger = logger
@@ -70,6 +72,9 @@ class EzLinksReplacer:
                     else:
                         # Otherwise, search for the target through the file map
                         search_result = self.file_map.search(self.path, link.target)
+                        if not self.use_directory_urls:
+                            search_result = search_result + '.md' if '.' not in search_result else search_result
+
                         if not search_result:
                             raise BrokenLink(f"'{link.target}' not found.")
                         link.target = search_result

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ with open("README.md", 'r') as f:
 
 setup(
   name='mkdocs-ezlinks-plugin',
-  version='0.1.10',
+  version='0.1.11',
   description=description,
   long_description=long_description,
   long_description_content_type='text/markdown',
   keywords='mkdocs',
   url='https://github.com/orbikm/mkdocs-ezlinks-plugin',
-  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.10.tar.gz',
+  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.11.tar.gz',
   author='Mick Orbik',
   author_email='mick.orbik@gmail.com',
   license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ with open("README.md", 'r') as f:
 
 setup(
   name='mkdocs-ezlinks-plugin',
-  version='0.1.9',
+  version='0.1.10',
   description=description,
   long_description=long_description,
   long_description_content_type='text/markdown',
   keywords='mkdocs',
   url='https://github.com/orbikm/mkdocs-ezlinks-plugin',
-  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.9.tar.gz',
+  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.10.tar.gz',
   author='Mick Orbik',
   author_email='mick.orbik@gmail.com',
   license='MIT',

--- a/test/docs/disambiguation/sub1/sub2/index.md
+++ b/test/docs/disambiguation/sub1/sub2/index.md
@@ -1,0 +1,3 @@
+# Sub2/Index
+
+[About (should link to sub2/about)](about)

--- a/test/docs/disambiguation/sub3/sub4/index.md
+++ b/test/docs/disambiguation/sub3/sub4/index.md
@@ -1,0 +1,3 @@
+# Sub3/Sub4/index
+
+[Test (should goto sub4/about)](about)


### PR DESCRIPTION
This is a bugfix release. The prior release switched from a dictionary lookup to a prefix trie lookup strategy, which allowed for better disambiguation between links, but is more expensive. The bug was that, even if a link was direct, it would trigger a full trie search. Now, direct links
are checked and returned directly if the file exists.

Additionally, a slight performance improvement was made where, in the case that a filename is unique to the entire site, it will rely on a fast dictionary lookup instead of a trie lookup.

Resolves: #19