### PR TITLE
Release 0.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In the circumstance above, it would be possible to disambiguate _which_ `test.md
 
 This disambiguation can continue with as many parent directories are specified, for instance `folder1/subfolder1/subfolder2/test.md`, specifying as many path components as necessary to fully disambiguate the links.
 
-This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]].
+This method of disambiguation is supported by each of the supported link formats (MD links, wiki/roamlinks). For instance, you can use `[[folder1/index|Link Title]]` and `[[folder2/index.md]]`.
 
 ## wikilinks
 Determines whether to scan for wikilinks or not (See [WikiLink Support](#wikilink-support)).
@@ -133,6 +133,14 @@ and these links are entered in `folder1/main.md`, this is how wikilinks will be 
 | `[[Page Name\|Link Text]]` | `[Link Text](../folder2/page-name.md)` |
 | `[[Page Name#Section Heading\|Link Text]]` | `[Link Text](../folder2/page-name.md#section-heading)` |
 
+# Release Log
+I am going to start tracking changes per release in this section. I will backfill the prior release history when I have a chance, but will maintain the release log for each new release.
+
+## Release 0.1.11
+This is a bugfix release. The prior release switched from a dictionary lookup to a prefix trie lookup strategy, which allowed for better disambiguation between links, but is more expensive. The bug was that, even if a link was direct, it would trigger a full trie search. Now, direct links
+are checked and returned directly if the file exists.
+
+Additionally, a slight performance improvement was made where, in the case that a filename is unique to the entire site, it will rely on a fast dictionary lookup instead of a trie lookup.
 
 # Attribution
 This work is highly inspired from the following plugins:

--- a/mkdocs_ezlinks_plugin/file_mapper.py
+++ b/mkdocs_ezlinks_plugin/file_mapper.py
@@ -16,6 +16,7 @@ class FileMapper:
             logger=None):
         self.options = options
         self.root = root
+        self.file_cache = {}
         self.file_trie = pygtrie.StringTrie(separator=os.sep)
         self.logger = logger
 
@@ -30,52 +31,76 @@ class FileMapper:
         # without file extension.
         search_exprs = [file_path, os.path.splitext(file_path)[0]]
         for search_expr in search_exprs:
+            # Store in fast file cache
+            file_name = os.path.basename(search_expr)
+            if file_name not in self.file_cache:
+                self.file_cache[file_name] = [file_path]
+            else:
+                self.file_cache[file_name].append(file_path)
+
+            # Store in trie
             components = list(search_expr.split(os.sep))
             components.reverse()
             self.file_trie[os.sep.join(components)] = file_path
 
-    def search(self, from_file: str, file_name: str):
-        abs_to = file_name
+        # Reduce the dictionary to only search terms that are unique
+        self.file_cache = {k: v for (k, v) in self.file_cache.items() if len(v) > 1}
+
+    def search(self, from_file: str, file_path: str):
+        abs_to = file_path
+        # Detect if it's an absolute link, then just return it directly
         if abs_to.startswith('/'):
-            abs_to = abs_to[1:]
+            return os.path.join(self.root, abs_to[1:])
         else:
-            search_for = list(file_name.split(os.sep))
-            search_for.reverse()
-            search_for = f"{os.sep}".join(search_for)
+            # Check if it is a direct link first
+            from_dir = os.path.dirname(from_file)
+            if os.path.exists(os.path.join(self.root, from_dir, file_path)):
+                return os.path.join(self.root, from_dir, file_path)
 
-            # If we have an _exact_ match in the trie, we don't need to search
-            if search_for in self.file_trie:
-                abs_to = self.file_trie[search_for]
-            elif self.file_trie.has_subtrie(search_for):
-                # If we don't have an exact match, but have a partial prefix
-                values = self.file_trie.values(search_for)
-                abs_to = values[0]
-                has_ambiguity = len(values) > 1
-                # If we have ambiguities, attempt to auto-disambiguate by performing
-                # an iterative ascent of the link file's path. In this way, we should
-                # be able to get the result closest to the file doing the linking
-                if has_ambiguity:
-                    file_path = os.path.dirname(from_file)
-                    components = file_path.split(os.sep)
-                    components.reverse()
-                    for path_component in components:
-                        search_for += f"{os.sep}{path_component}"
-                        if self.file_trie.has_subtrie(search_for) or search_for in self.file_trie:
-                            new_vals = self.file_trie.values(search_for)
-                            if len(new_vals) == 1:
-                                abs_to = new_vals[0]
-                                # We've resolved the ambiguity, so no need to warn
-                                has_ambiguity = False
-                                break
+            # It's an EzLink that must be searched
+            file_name = os.path.basename(file_path)
 
-                if has_ambiguity:
-                    ambiguities = ""
-                    for idx, file in enumerate(values):
-                        active = "<--- (Selected)" if idx == 0 else ""
-                        ambiguities += f"  {idx}: {file} {active}\n"
-                    log_fn = self.logger.warning if self.options.warn_ambiguities else self.logger.debug
-                    log_fn(f"[EzLink] Link ambiguity detected.\n"
-                           f"File: '{from_file}'\n"
-                           f"Link: '{search_for}'\n"
-                           "Ambiguities:\n" + ambiguities)
+            # Check fast file cache first
+            if os.path.basename(file_name) in self.file_cache:
+                abs_to = self.file_cache[file_name]
+            else:
+                search_for = list(file_path.split(os.sep))
+                search_for.reverse()
+                search_for = f"{os.sep}".join(search_for)
+
+                # If we have an _exact_ match in the trie, we don't need to search
+                if search_for in self.file_trie:
+                    abs_to = self.file_trie[search_for]
+                elif self.file_trie.has_subtrie(search_for):
+                    # If we don't have an exact match, but have a partial prefix
+                    values = self.file_trie.values(search_for)
+                    abs_to = values[0]
+                    has_ambiguity = len(values) > 1
+                    # If we have ambiguities, attempt to auto-disambiguate by performing
+                    # an iterative ascent of the link file's path. In this way, we should
+                    # be able to get the result closest to the file doing the linking
+                    if has_ambiguity:
+                        file_path = os.path.dirname(from_file)
+                        components = file_path.split(os.sep)
+                        components.reverse()
+                        for path_component in components:
+                            search_for += f"{os.sep}{path_component}"
+                            if self.file_trie.has_subtrie(search_for) or search_for in self.file_trie:
+                                new_vals = self.file_trie.values(search_for)
+                                if len(new_vals) == 1:
+                                    abs_to = new_vals[0]
+                                    # We've resolved the ambiguity, so no need to warn
+                                    has_ambiguity = False
+                                    break
+
+                    if has_ambiguity:
+                        ambiguities = ""
+                        for idx, file in enumerate(values):
+                            active = "<--- (Selected)" if idx == 0 else ""
+                            ambiguities += f"  {idx}: {file} {active}\n"
+                        log_fn = self.logger.warning if self.options.warn_ambiguities else self.logger.debug
+                        log_fn(f"[EzLink] Link ambiguity detected.\n"
+                               f"File: '{from_file}'\n"
+                               f"Link: '{search_for}'\n"
+                               "Ambiguities:\n" + ambiguities)
         return os.path.join(self.root, abs_to)

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ with open("README.md", 'r') as f:
 
 setup(
   name='mkdocs-ezlinks-plugin',
-  version='0.1.10',
+  version='0.1.11',
   description=description,
   long_description=long_description,
   long_description_content_type='text/markdown',
   keywords='mkdocs',
   url='https://github.com/orbikm/mkdocs-ezlinks-plugin',
-  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.10.tar.gz',
+  download_url='https://github.com/orbikm/mkdocs-ezlinks-plugin/archive/v_0.1.11.tar.gz',
   author='Mick Orbik',
   author_email='mick.orbik@gmail.com',
   license='MIT',


### PR DESCRIPTION
This is a bugfix release. The prior release switched from a dictionary lookup to a prefix trie lookup strategy, which allowed for better disambiguation between links, but is more expensive. The bug was that, even if a link was direct, it would trigger a full trie search. Now, direct links
are checked and returned directly if the file exists.

Additionally, a slight performance improvement was made where, in the case that a filename is unique to the entire site, it will rely on a fast dictionary lookup instead of a trie lookup.

Resolves: #19 