### PR TITLE
Treat any link containing protocol scheme as ext

### DIFF
--- a/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
+++ b/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
@@ -12,6 +12,7 @@ class MdLinkScanner(BaseLinkScanner):
         # | md_is_image      |  Contains ! when an image tag, or empty if not (check both)      |
         # | md_alt_is_image  |  Contains ! when an image tag, or empty if not (check both)      |
         # | md_text          |  Contains the Link Text between [md_text]                        |
+        # | md_protocol      |  Rejects match if link contains a protocol scheme (e.g. http)    |
         # | md_target        |  Contains the full target of the Link (filename.md#anchor)       |
         # | md_filename      |  Contains just the filename portion of the target (filename.md)  |
         # | md_anchor        |  Contains the anchor, if present (e.g. `file.md#anchor`)         |
@@ -29,7 +30,7 @@ class MdLinkScanner(BaseLinkScanner):
             )
             \(
                 (?P<md_target>
-                    (?!http://|https://)
+                    (?!(?P<md_protocol>[a-z][a-z0-9+\-.]*:\/\/))
                     (?P<md_filename>\/?[^\#\ \)]*)?
                     (?:\#(?P<md_anchor>[^\)\"]*)?)?
                     (?:\ \"(?P<md_title>[^\"\)]*)\")?

--- a/test/docs/my-project/link_updates.md
+++ b/test/docs/my-project/link_updates.md
@@ -13,11 +13,24 @@
 [[#Section Heading|Title]]
 
 
-
+## External Links, containing schemes
 [External Link](https://www.example.com)
+
 [External Link](http://www.example.com)
+
+[External Link](mailto://person@example.com)
+
+[External Link](dig://example.com)
+
+[External Link](ftp://example.com)
+
+[External Link](ssh://example.com)
+
 [External Link w/ Title](https://www.example.com "LINK TITLE")
-[External link no scheme](www.example.com)
+
+[External link no scheme](www.example.com) (broken)
+
+
 
 MD Links:
 


### PR DESCRIPTION
This expands the existing behavior of ignoring `http://` and `https://` schemes (which _were_ hardcoded into the regex) with a greedier Regex that rejects any link that contains any valid protocol scheme in the link.

A big thanks to @robbcrg for the bug report as well as a proof of concept PR (#26)!