### PR TITLE
Fix fast file cache reduction

### DIFF
--- a/mkdocs_ezlinks_plugin/file_mapper.py
+++ b/mkdocs_ezlinks_plugin/file_mapper.py
@@ -44,7 +44,7 @@ class FileMapper:
             self.file_trie[os.sep.join(components)] = file_path
 
         # Reduce the dictionary to only search terms that are unique
-        self.file_cache = {k: v for (k, v) in self.file_cache.items() if len(v) > 1}
+        self.file_cache = {k: v for (k, v) in self.file_cache.items() if len(v) == 1}
 
     def search(self, from_file: str, file_path: str):
         abs_to = file_path
@@ -62,7 +62,7 @@ class FileMapper:
 
             # Check fast file cache first
             if os.path.basename(file_name) in self.file_cache:
-                abs_to = self.file_cache[file_name]
+                abs_to = self.file_cache[file_name][0]
             else:
                 search_for = list(file_path.split(os.sep))
                 search_for.reverse()


### PR DESCRIPTION
* Previously, an attempt was made to speed up the most naive case of
  EzLink conversion, where there is a unique filename across the entire
  site. This would allow a simple dictionary lookup instead of a full
  Prefix Trie search (which is more expensive).

  Previously, it incorrectly trimmed _all_ files from the file cache
  when reducing it to unique items, because the dictionary comprehension
  had an inverted comparison operator.

  Now, unique file names will be directly converted via the fast file
  cache.