### PR TITLE
Fix `warning_filter` warning

### DIFF
--- a/mkdocs_ezlinks_plugin/plugin.py
+++ b/mkdocs_ezlinks_plugin/plugin.py
@@ -2,7 +2,6 @@ import logging
 from typing import List
 
 import mkdocs
-from mkdocs.utils import warning_filter
 
 from .file_mapper import FileMapper
 from .replacer import EzLinksReplacer
@@ -12,7 +11,6 @@ from .scanners.reference_link_scanner import ReferenceLinkScanner
 from .types import EzLinksOptions
 
 LOGGER = logging.getLogger(f"mkdocs.plugins.{__name__}")
-LOGGER.addFilter(warning_filter)
 
 
 class EzLinksPlugin(mkdocs.plugins.BasePlugin):


### PR DESCRIPTION
Prevents this warning from MkDocs 1.6.0:

```shell
$ pdm run mkdocs build
INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the
           `mkdocs` logger get counted automatically.
             File
           ".../.venv/lib/python3.10/site-packages/mkdocs_ezlinks_plugin/plugin.py",
           line 5, in <module>
               from mkdocs.utils import warning_filter
             File ".../.venv/lib/python3.10/site-packages/mkdocs/utils/__init__.py",
           line 403, in __getattr__
               warnings.warn(
```